### PR TITLE
change target version check to <= instead of !==

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,9 +194,15 @@ function resolveHandler( tester ) {
 
         try {
 
-            if( checkVersion && (process.versions.node !== TARGET_NODE_VERSION) ) {
+            if( checkVersion && (process.versions.node < TARGET_NODE_VERSION) ) {
 
-                throw new Error( 'Please test with node.js ' + TARGET_NODE_VERSION );
+                throw new Error( 'Please test with node.js >= ' + TARGET_NODE_VERSION );
+            }
+
+            if( checkVersion && (process.versions.node >= '7.0.0') ) {
+
+                throw new Error( 'node.js 7.x is not currently supported '
+                                 + 'please test with an older version.' );
             }
 
             if( tester._loadHandler ) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "variables"
   ],
   "engines": {
-    "node": ">=4.3.2"
+    "node": ">=4.3.2 <7.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -1508,25 +1508,39 @@ describe( 'lib/index', function() {
                     .expectResult();
             });
 
-            it( 'with version checking (wrong node version)', function() {
+            it( 'with version checking (older node version)', function() {
 
                 process = Object.assign( {}, originalProcess );
-                process.versions =  { node: '9.9.9' };
+                process.versions =  { node: '4.3.1' };
 
                 return LambdaTester( LAMBDA_SIMPLE_CALLBACK )
                     .expectResult()
                     .then(
                         () => {
-
                             throw new Error( 'should not work' );
                         },
                         ( err ) => {
-
                             expect( err.message ).to.contain( 'Please test with node.js' );
                         }
                     );
             });
 
+            it( 'with version checking (node 7.0.0)', function() {
+
+                process = Object.assign( {}, originalProcess );
+                process.versions =  { node: '7.0.0' };
+
+                return LambdaTester( LAMBDA_SIMPLE_CALLBACK )
+                    .expectResult()
+                    .then(
+                        () => {
+                            throw new Error( 'should not work' );
+                        },
+                        ( err ) => {
+                            expect( err.message ).to.contain( 'node.js 7.x is not currently supported' );
+                        }
+                    );
+            });
         });
     });
 });


### PR DESCRIPTION
Having the version check be `!==` made the package only work on 1
very specific version of nodejs `4.3.2`, this is an undesired behavior
and doesn't reflect the target version inside the package.json

These changes make this version check match the version requirements
defined inside the package.json `>= 4.3.2` and also adds a check to
make sure the node version isn't greater then `7.0.0` as this version
isn't currently supported by this package.

This is a fix to #13 