### PR TITLE
event(evt) should not convert falsy evt to empty Object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -515,6 +515,8 @@ LambdaTesterModule.noVersionCheck = function() {
     checkVersion = false;
 }
 
+LambdaTesterModule.LambdaTester = LambdaTester;
+
 // Set the task root to the app's root if not already set
 process.env.LAMBDA_TASK_ROOT = require( 'app-root-path' );
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -515,8 +515,6 @@ LambdaTesterModule.noVersionCheck = function() {
     checkVersion = false;
 }
 
-LambdaTesterModule.LambdaTester = LambdaTester;
-
 // Set the task root to the app's root if not already set
 process.env.LAMBDA_TASK_ROOT = require( 'app-root-path' );
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -284,8 +284,6 @@ class LambdaTester {
 
     event( evt ) {
 
-        evt = evt || {};
-
         if( utils.isObject( evt ) && !Array.isArray( evt ) ) {
 
             this._event = Object.assign( {}, evt );

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -206,15 +206,6 @@ describe( 'lib/index', function() {
                 expect( tester._event ).to.not.equal( event );
             });
 
-            it( 'event missing', function() {
-
-                let tester = LambdaTester( LAMBDA_SIMPLE_SUCCEED );
-
-                tester.event();
-
-                expect( tester._event ).to.eql( {} );
-            });
-
             it( 'event is array of events', function() {
 
                 let tester = LambdaTester( LAMBDA_SIMPLE_SUCCEED );


### PR DESCRIPTION
It is perfectly legal to pass a falsy event value (e.g., `null`, `false`, `0`, etc.) to a Lambda function. Therefore, it is not valid for event(evt) to arbitrarily convert falsy arguments to an empty Object, as that would completely change what was intended.