### PR TITLE
fixed default timeout so it is not enforced by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const utils = require( './utils' );
 
 const config = require( './config' );
 
-const DEFAULT_TIMEOUT = 3000; // s3
+const DEFAULT_TIMEOUT = 0;
 
 const TARGET_NODE_VERSION = '6.10.1';
 


### PR DESCRIPTION
With default timeout of 3000 in `LambdaTester`, `LambdaRunner` tries to enforce it by default, because
```js
this.enforceTimeout = (options.timeout > 0);
```

`enforceTimeout` field should probably be removed from `LambdaTester`, as it's not used.