### PR TITLE
Add support for JSON-formatted env files

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -1,5 +1,11 @@
 # Using Environment Variables
 
-Environment variables can be set and read automatically by placing a `.env` file in the base path of
-your Lambda handler project. For more information about configuring your `.env` file, see the author's
+Environment variables can be set and read automatically by placing an `.env` file in the base path of your Lambda handler project, or by using lambda-tester's [configurations settings](configuration.md) to specify a file.
+
+To use a JSON format, put a `.json` extension at the end of your file name. Remember to add this to your `.gitignore` file (or similar) so that you don't accidentally commit it to a repository.
+
+For more information about configuring an `.env` file, see the author's
 [documentation](https://github.com/motdotla/dotenv).
+
+For more information about configuring an `.env.json` file, see the author's
+[documentation](https://github.com/maxbeatty/dotenv-json)

--- a/lib/index.js
+++ b/lib/index.js
@@ -277,8 +277,16 @@ if( !process.env.LAMBDA_TESTER_NO_ENV ) {
 
     let path = config.envFile || '.env';
 
-    // configure env varaiables
-    require( 'dotenv' ).config( { path } );
+    const isJson = path.endsWith('.json');
+    // configure env variables
+    if ( isJson ) {
+
+      require( 'dotenv-json' )( { path } );
+    }
+    else {
+
+      require( 'dotenv' ).config( { path } );
+    }
 }
 
 module.exports = LambdaTesterModule;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "app-root-path": "^2.0.1",
     "dotenv": "^4.0.0",
+    "dotenv-json": "^1.0.0",
     "lambda-leak": "^2.0.0",
     "uuid": "^3.0.1",
     "vandium-utils": "^1.1.1"

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -1470,6 +1470,7 @@ describe( 'lib/index', function() {
                 delete process.env.LAMBDA_TESTER_NO_ENV;
 
                 freshy.unload( 'dotenv' );
+                freshy.unload( 'dotenv-json' );
 
                 freshy.unload( LAMBDA_TESTER_PATH );
                 freshy.unload( LAMBDA_TESTER_CONFIG_PATH );
@@ -1558,6 +1559,18 @@ describe( 'lib/index', function() {
                 expect( process.env.TEST_VALUE ).to.exist;
                 expect( process.env.TEST_VALUE ).to.equal( 'test-deploy' );
             });
+
+            it( 'with custom .env.json file', function() {
+
+              envPath = appRoot + '/.env.json';
+              fs.writeFileSync( envPath, '{"TEST_VALUE":"test-json"}' );
+              fs.writeFileSync( appRoot + '/.lambda-tester.json', JSON.stringify( { envFile: '.env.json' } ) );
+
+              LambdaTester = require( LAMBDA_TESTER_PATH );
+
+              expect( process.env.TEST_VALUE ).to.exist;
+              expect( process.env.TEST_VALUE ).to.equal( 'test-json' );
+          });
         });
 
         describe( '.noVersionCheck', function() {


### PR DESCRIPTION
* Allows handling of JSON-formatted env files
* Will enable support for using env files in [serverless](https://serverless.com/)-based apps, where external files must be in either a [JSON or YAML format](https://serverless.com/framework/docs/providers/aws/guide/variables/), e.g. `environment: ${file(.env.json)}`
