### PR TITLE
Enable wildcard node support for versions 6.x.x and 8.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "x-ray"
   ],
   "engines": {
-    "node": ">=6.0.0 <7.0.0"
+    "node": "^6.0.0 ^8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently amazon supports various versions of node.  The `engines` attribute in the package.json file appears to help the user "know" if they are on a supported version or not...

This likely will be changing in the future and something that the developer has recognized must be maintained.

In order to do "less" updates it is recommended to do a "wildcard" for minor and patch versions.

Current versions supported:
https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html