### PR TITLE
Improve version checking at startup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,15 +22,44 @@ function doVersionCheck() {
 
         return;
     }
-
-    if( process.versions.node < TARGET_NODE_VERSION ) {
+    
+    if( versionLessThan( process.versions.node, TARGET_NODE_VERSION )) {
 
         throw new Error( 'Please test with node.js >= ' + TARGET_NODE_VERSION );
     }
-    else if ( process.versions.node >= '8.11.0' ) {
+    else if ( !versionLessThan( process.versions.node, '8.11.0' )) {
 
         throw new Error( 'node.js version is not currently supported, please test with an older version.' );
     }
+}
+
+function versionLessThan( leftVersionStr, rightVersionStr ) {
+    var versionRegex = /(\d+)\.(\d+)\.(\d+)/;
+    
+    var leftVersion = versionRegex.exec( leftVersionStr ).slice( 1 ).map( x => parseInt( x ) );
+    if( leftVersion.length != 3 ) {
+        throw new Error( 'could not parse leftVersionStr: ' + JSON.stringify( leftVersionStr ) );
+    }
+
+    var rightVersion = versionRegex.exec( rightVersionStr ).slice( 1 ).map( x => parseInt( x ) );
+    if( rightVersion.length != 3 ) {
+        throw new Error( 'could not parse rightVersionStr: ' + JSON.stringify( rightVersionStr ) );
+    }
+
+    var result = false;
+    if( leftVersion[0] < rightVersion[0] ) {
+        result = true;
+    }
+    else if( leftVersion[0] === rightVersion[0] ) {
+        if( leftVersion[1] < rightVersion[1] ) {
+            result = true;
+        }
+        else if( leftVersion[1] === rightVersion[1] ) {
+            result = (leftVersion[2] < rightVersion[2]);
+        }
+    }
+
+    return result;
 }
 
 function resolveHandler( tester ) {


### PR DESCRIPTION
Hi, I noticed the string comparison wasn't working for version checks.

String-comparison doesn't work in same cases, for example, "8.10.0" < "8.9.0".  So, this parses the string arrays and uses a multi-digit numeric comparison.

Feel free to use this code however you like.