### PR TITLE
Added support for handlers that return promises

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Simplifies writing unit tests for [AWS Lambda](https://aws.amazon.com/lambda/det
 - [Getting Started](getting-started.md)
 - [Verifying `context.succeed()`, `context.fail` and `context.done()`](context-succeed-fail-done.md)
 - [Verifying `callback()`](callback.md)
+- [Verifying `Promise.resolve()` and `Promise.reject()`](promise.md)
 - [Custom Event Values](events.md)
 - [Resource Leak Detection](leak-detection.md)
 - [Detecting Handlers than Run for Too Long](long-running-handlers.md)

--- a/docs/promise.md
+++ b/docs/promise.md
@@ -1,0 +1,153 @@
+# Verifying Promises
+
+On April 2, 2018 AWS Lambda introduced support for Node.js 8.10 and Lambda handlers that can return a promise directly -
+eliminating the need to invoke the callback previously passed to the handler or the earlier `context.fail()`,
+`context.succeed()` and `context.done()` methods.
+
+
+## Verifying `Promise.resolve()`
+
+When the Lambda handler returns a `Promise` that resolves, verification can be performed using `expectResolve()`. If the handler calls
+anything other function or the `Promise` rejects, then the test will fail.
+
+```js
+const LambdaTester = require( 'lambda-tester' );
+
+const myHandler = require( '../index' ).handler;
+
+describe( 'handler', function() {
+
+	it( 'test callback( null, result )', function() {
+
+		return LambdaTester( myHandler )
+			.event( { name: 'Fred' } )
+			.expectResolve();
+	});
+});
+```
+
+To verify the `result` value from `Promise.resolve`:
+
+```js
+const LambdaTester = require( 'lambda-tester' );
+
+// Mocha using Chai
+const expect = require( 'chai' ).expect;
+
+const myHandler = require( '../index' ).handler;
+
+describe( 'handler', function() {
+
+	it( 'test callback( null, result )', function() {
+
+		return LambdaTester( myHandler )
+			.event( { name: 'Fred' } )
+			.expectResolve( ( result, additional ) => {
+
+                expect( result.userId ).to.exist;
+                expect( result.user ).to.equal( 'fredsmith' );
+            });
+	});
+});
+```
+
+The `additional` parameter contains information such as AWS x-ray data and execution information. The function passed to `expectResolve()` can return a `Promise` to perform asynchronous operation. Operations that require a callback for asynchronous operations can use the `done` parameter:
+
+```js
+const LambdaTester = require( 'lambda-tester' );
+
+// Mocha using Chai
+const expect = require( 'chai' ).expect;
+
+const myHandler = require( '../index' ).handler;
+
+const asyncOperation = require( '../my-async-op' );
+
+describe( 'handler', function() {
+
+	it( 'test callback( null, result )', function() {
+
+		return LambdaTester( myHandler )
+			.event( { name: 'Fred' } )
+			.expectResolve( ( result, additional, done ) => {
+
+                // this function will call done when complete
+                asyncOperation( result, done );
+            });
+	});
+});
+```
+
+## Verifying `Promise.reject()`
+
+When the Lambda handler returns a `Promise` that rejects, verification can be performed using `expectReject()`. If the handler calls
+anything other function or the `Promise` resolves, then the test will fail.
+
+
+```js
+const LambdaTester = require( 'lambda-tester' );
+
+const myHandler = require( '../index' ).handler;
+
+describe( 'handler', function() {
+
+	it( 'test callback( err )', function() {
+
+		return LambdaTester( myHandler )
+			.event( { name: 'Unknown' } )
+			.expectReject();
+	});
+});
+```
+
+To verify the value of `err` from `Promise.reject()`, pass a validator to `expectReject()`:
+
+```js
+const LambdaTester = require( 'lambda-tester' );
+
+// Mocha using Chai
+const expect = require( 'chai' ).expect;
+
+const myHandler = require( '../index' ).handler;
+
+describe( 'handler', function() {
+
+	it( 'test callback( err )', function() {
+
+		return LambdaTester( myHandler )
+			.event( { name: 'Unknown' } )
+			.expectReject( ( err, additional ) => {
+
+				expect( err.message ).to.equal( 'User not found' );
+			});
+	});
+});
+```
+
+The `additional` parameter contains information such as AWS x-ray data and execution information. The function passed to `expectReject()` can return a `Promise` to perform asynchronous operation. Operations that require a callback for asynchronous operations can use the `done` parameter:
+
+```js
+const LambdaTester = require( 'lambda-tester' );
+
+// Mocha using Chai
+const expect = require( 'chai' ).expect;
+
+const myHandler = require( '../index' ).handler;
+
+const asyncOperation = require( '../my-async-op' );
+
+describe( 'handler', function() {
+
+	it( 'test callback( err )', function() {
+
+		return LambdaTester( myHandler )
+			.event( { name: 'Unknown' } )
+			.expectReject( ( err, additional, done ) => {
+
+                asyncOperation( err, done );
+			});
+	});
+});
+```
+
+**Note:** Promise verification cannot be used to verify `callback()`, `context.succeed()`, `context.fail()` or `context.done()`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const semver = require('semver')
+const semver = require('semver');
 
 const LambdaRunner = require( './runner' );
 
@@ -237,6 +237,35 @@ class LambdaTester {
             .then( ( handler ) => {
 
                 return new LambdaRunner( 'callback:result', resultVerifier, this.options )
+                        .withEvent( this._event )
+                        .withContext( this._context, true )
+                        .run( handler );
+
+            });
+
+        return addVerify( addCleanup( promise, this ) );
+    }
+
+    expectReject( resultVerifier ) {
+
+        let promise = resolveHandler( this )
+            .then( ( handler ) => {
+
+                return new LambdaRunner( 'Promise.reject', resultVerifier, this.options )
+                        .withEvent( this._event )
+                        .withContext( this._context, true )
+                        .run( handler );
+            });
+
+        return addVerify( addCleanup( promise, this ) );
+    }
+
+    expectResolve( resultVerifier ) {
+
+        let promise = resolveHandler( this )
+            .then( ( handler ) => {
+
+                return new LambdaRunner( 'Promise.resolve', resultVerifier, this.options )
                         .withEvent( this._event )
                         .withContext( this._context, true )
                         .run( handler );

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -63,9 +63,11 @@ function processOutcome( method, expectedOutcome, handlerResult ) {
     switch( method ) {
 
         case 'context.fail':
+        case 'Promise.reject':
             return err;
 
         case 'context.succeed':
+        case 'Promise.resolve':
             return handlerResult.result;
 
         //case 'callback':
@@ -240,7 +242,20 @@ class LambdaRunner {
 
                         let callback = ( err, result ) => resolve( { method: 'callback', err, result } );
 
-                        handler( this.event, context, callback );
+                        const ret = handler( this.event, context, callback );
+
+                        if( ret && ret.then && typeof(ret.then) === 'function' ) {
+
+                            ret
+                                .then((result) => {
+
+                                    resolve( { method: 'Promise.resolve', err: null, result } )
+                                },
+                                (err) => {
+
+                                    resolve( { method: 'Promise.reject', err, result: null } )
+                                });
+                        }
                     }
                     catch( error ) {
 

--- a/test/lib/runner.test.js
+++ b/test/lib/runner.test.js
@@ -138,7 +138,64 @@ describe( 'lib/runner', function() {
 
                         expect( context.getRemainingTimeInMillis() ).to.be.above( 0 );
 
-                        callback( new Error( 'bang') );
+                        callback( new Error( 'bang' ) );
+                    });
+            });
+
+            it( 'successful Promise.resolve using defaults', function() {
+
+                let instance = new LambdaRunner( 'Promise.resolve', null, {} ).withEvent( {} );
+
+                return instance.run( (event, context) => {
+
+                        expect( event ).to.eql( {} );
+                        expect( context ).to.exist;
+                        expect( context.functionName ).to.exist;
+
+                        expect( context.getRemainingTimeInMillis() ).to.be.above( 0 );
+
+                        return Promise.resolve( 'ok' );
+                    });
+            });
+
+            it( 'successful Promise.resolve with event, context, and verifier', function() {
+
+                let verifier = sinon.stub();
+
+                let instance = new LambdaRunner( 'Promise.resolve', verifier, { checkForHandleLeak: true } )
+                    .withEvent( { answer: 42 } )
+                    .withContext( { whatever: true } );
+
+                return instance.run( (event, context) => {
+
+                        expect( event ).to.eql( { answer: 42 } );
+                        expect( context ).to.exist;
+                        expect( context.functionName ).to.exist;
+                        expect( context.whatever ).to.be.true;
+
+                        return Promise.resolve( 'ok' );
+                    })
+                    .then( () => {
+
+                        expect( verifier.calledOnce ).to.be.true;
+                        expect( verifier.firstCall.args[0] ).to.equal( 'ok' );
+                        expect( verifier.firstCall.args[1].execTime ).to.exist;
+                    });
+            });
+
+            it( 'successful Promise.reject using defaults', function() {
+
+                let instance = new LambdaRunner( 'Promise.reject', null, {} ).withEvent( {} );
+
+                return instance.run( (event, context) => {
+
+                        expect( event ).to.eql( {} );
+                        expect( context ).to.exist;
+                        expect( context.functionName ).to.exist;
+
+                        expect( context.getRemainingTimeInMillis() ).to.be.above( 0 );
+
+                        return Promise.reject( new Error( 'bang' ) );
                     });
             });
 


### PR DESCRIPTION
With Node.js 8.10, your lambda handler can now directly return a promise instead of invoking `callback()`. `context.fail()`, `context.succeed()` or `context.done()`.

https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/

This PR adds two new expect methods, `expectResolve()` and `expectReject()`, to support handlers that return promises.