### PR TITLE
add async handler function support in run method

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -240,7 +240,13 @@ class LambdaRunner {
 
                         let callback = ( err, result ) => resolve( { method: 'callback', err, result } );
 
-                        handler( this.event, context, callback );
+                        let ret = handler( this.event, context, callback );
+
+                        if (ret && typeof ret.then === 'function') {
+                            ret.then((result) => {
+                                callback(null, result);
+                            }).catch(callback);
+                        }
                     }
                     catch( error ) {
 


### PR DESCRIPTION
#### Description
Since AWS released lambda supporting Node v8.10.0 handler functions can be `async` functions that do not have to call the `callback` https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/.

This PR is a simplistic representation of how to implement such functionality. I'm not sure if this functionality is already implemented and I just missed it but would like to start a discussion around how to implement this feature if it isn't already.