### PR TITLE
Add support for node 10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Simplifies writing unit tests for [AWS Lambda](https://aws.amazon.com/lambda/det
 * Lightweight and won't impact performance
 * Maps the environment variable `LAMBDA_TASK_ROOT` to the application's root
 * Automatically loads .env files
-* Works with Node 8.x
+* Works with Node 8.10.x and 10.x
 
 ## Installation
 Install via npm.

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const config = require( './config' );
 
 const DEFAULT_TIMEOUT = 0;
 
-const SUPPORTED_NODE_RANGE = '8.10.0 - 8.999.0';
+const SUPPORTED_NODE_RANGE = '8.10.0 - 8.999.0 || 10.0.0 - 10.999.0';
 
 var checkForHandleLeak = false;
 


### PR DESCRIPTION
Since yesterday AWS released node 10 support for AWS Lambda.
Version 10 has been added when checking for versions.