### PR TITLE
Display real stack traces

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -28,9 +28,12 @@ class FailError extends Error {
 
         super( message );
 
-        this.cause = convertError( cause );
         this.result = result;
-        this.stack = cause.stack;
+
+        if (cause) {
+            this.cause = convertError( cause );
+            this.stack = cause.stack;
+        }
     }
 }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -30,6 +30,7 @@ class FailError extends Error {
 
         this.cause = convertError( cause );
         this.result = result;
+        this.stack = cause.stack;
     }
 }
 

--- a/test/lib/runner.test.js
+++ b/test/lib/runner.test.js
@@ -231,7 +231,7 @@ describe( 'lib/runner', function() {
                     });
             });
 
-            it( 'unexpected failure when context.succeed expected', function() {
+            it( 'maintains the stack when there is an unexpected failure and context.succeed expected', function() {
 
                 let instance = new LambdaRunner( 'context.succeed', null, {} ).withEvent( {} );
 

--- a/test/lib/runner.test.js
+++ b/test/lib/runner.test.js
@@ -231,6 +231,25 @@ describe( 'lib/runner', function() {
                     });
             });
 
+            it( 'unexpected failure when context.succeed expected', function() {
+
+                let instance = new LambdaRunner( 'context.succeed', null, {} ).withEvent( {} );
+
+                return instance.run( (event, context) => {
+                        return new Promise(() => {
+                            throw new Error('Bang');
+                        });
+                    }).then(
+                        () => {
+
+                            throw new Error( 'should not resolve' );
+                        },
+                        (err) => {
+                            expect( err.stack ).to.contain( 'runner.test.js' );
+                        }
+                    );
+            });
+
             it( 'successful context.fail using defaults', function() {
 
                 let instance = new LambdaRunner( 'context.fail', null, { timeout: 3000 } ).withEvent( {} );


### PR DESCRIPTION
Pull request to address: https://github.com/vandium-io/lambda-tester/issues/49

When you expect success but your lambda throws an error it now copies the stack trace of your error so it's easier to fix.