### PR TITLE
Add support for node 12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Simplifies writing unit tests for [AWS Lambda](https://aws.amazon.com/lambda/det
 * Lightweight and won't impact performance
 * Maps the environment variable `LAMBDA_TASK_ROOT` to the application's root
 * Automatically loads .env files
-* Works with Node 8.10.x and 10.x
+* Works with Node 8.10.x, 10.x, and 12.x
 
 ## Installation
 Install via npm.

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const config = require( './config' );
 
 const DEFAULT_TIMEOUT = 0;
 
-const SUPPORTED_NODE_RANGE = '8.10.0 - 8.999.0 || 10.0.0 - 10.999.0';
+const SUPPORTED_NODE_RANGE = '8.10.0 - 8.999.0 || 10.0.0 - 10.999.0 || 12.0.0 - 12.999.0';
 
 var checkForHandleLeak = false;
 


### PR DESCRIPTION
AWS released support for Node 12.x yesterday:
https://aws.amazon.com/blogs/compute/node-js-12-x-runtime-now-available-in-aws-lambda/

This PR was modeled after the Node 10.x upgrade (#50).