### PR TITLE
Better Simulation of Lambda Input and Output

### DIFF
--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -283,7 +283,7 @@ describe( 'lib/index', function() {
 
                 expect( tester._event ).to.eql( {} );
 
-                let returnValue = tester.event( { one: 1 } );
+                let returnValue = tester.event( { one: 1, dummy: undefined } );
 
                 expect( returnValue ).to.equal( tester );
                 expect( tester._event ).to.eql( { one: 1 } );
@@ -309,8 +309,8 @@ describe( 'lib/index', function() {
                 tester.event( [ e1, e2 ] );
 
                 expect( tester._event ).to.be.an( 'Array' );
-                expect( tester._event[0] ).to.equal( e1 );
-                expect( tester._event[1] ).to.equal( e2 );
+                expect( tester._event[0] ).to.eql( e1 );
+                expect( tester._event[1] ).to.eql( e2 );
             });
 
             it( 'event is a function', function() {

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -429,7 +429,7 @@ describe( 'lib/index', function() {
                 return tester.expectResult( ( result ) => {
 
                         // should be the original object
-                        expect( result ).to.equal( clientContext );
+                        expect( result ).to.eql( clientContext );
                     });
             });
 
@@ -456,7 +456,7 @@ describe( 'lib/index', function() {
                 return tester.expectResult( ( result ) => {
 
                         // should be the original object
-                        expect( result ).to.equal( clientContext );
+                        expect( result ).to.eql( clientContext );
                     });
             });
         });
@@ -1468,34 +1468,68 @@ describe( 'lib/index', function() {
 
                 await LambdaTester( (event, context) => {
 
-                        context.succeed( 'ok' );
+                        context.succeed( { ok: true, dummy: undefined } );
                     }).expectResult( (result) => {
 
-                        expect( result ).to.equal( 'ok' );
+                        expect( result ).to.eql( { ok: true } );
                     });
+            });
+
+            it( 'without strict mode, contextSucceed with no value', async function() {
+
+                await LambdaTester( (event, context) => {
+
+                    context.succeed();
+                }).expectResult( (result) => {
+
+                    expect( result ).to.equal( null );
+                });
             });
 
             it( 'without strict mode, callback', async function() {
 
                 await LambdaTester( (event, context, callback) => {
 
-                        callback( null, 'ok' );
+                        callback( null, { ok: true, dummy: undefined } );
                     }).expectResult( (result) => {
 
-                        expect( result ).to.equal( 'ok' );
+                        expect( result ).to.eql( { ok: true } );
                     });
+            });
+
+            it( 'without strict mode, callback with no value', async function() {
+
+                await LambdaTester( (event, context, callback) => {
+
+                    callback( null );
+                }).expectResult( (result) => {
+
+                    expect( result ).to.equal( null );
+                });
             });
 
             it( 'without strict mode, promise', async function() {
 
                 await LambdaTester( () => {
 
-                        return Promise.resolve( 'ok' );
+                        return Promise.resolve( { ok: true, dummy: undefined } );
 
                     }).expectResult( (result) => {
 
-                        expect( result ).to.equal( 'ok' );
+                        expect( result ).to.eql( { ok: true } );
                     });
+            });
+
+            it( 'without strict mode, promise with no value', async function() {
+
+                await LambdaTester( () => {
+
+                    return Promise.resolve();
+
+                }).expectResult( (result) => {
+
+                    expect( result ).to.equal( null );
+                });
             });
 
             it( 'without verifier', function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,14 +148,7 @@ class LambdaTester {
             evt = evt( lambdaEventMock );
         }
 
-        if( isObject( evt ) && !Array.isArray( evt )) {
-
-            this._event = { ...evt };
-        }
-        else {
-
-            this._event = evt;
-        }
+        this._event = JSON.parse( JSON.stringify( evt ) )
 
         return this;
     }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -122,6 +122,11 @@ async function runVerifier( verifier, result, additional ) {
     }
 }
 
+// This function simulates the serialization process between the client and the lambda service.
+function convertResult( result ) {
+    return result === undefined ? null : JSON.parse( JSON.stringify( result ) );
+}
+
 class LambdaRunner {
 
     constructor( expectedState, verifier, options = {} ) {
@@ -164,14 +169,14 @@ class LambdaRunner {
 
                 let context = this._createContext( resolve, { startTime } );
 
-                let callback = ( err, result ) => resolve( { state: err ? States.callbackError : States.callbackResult, err, result } );
+                let callback = ( err, result ) => resolve( { state: err ? States.callbackError : States.callbackResult, err, result: convertResult( result ) } );
 
                 const ret = handler( this.event, context, callback );
 
                 if( isPromise( ret ) ) {
 
                     ret.then(
-                        (result) => resolve( { state: States.promiseResolve, err: null, result } ),
+                        (result) => resolve( { state: States.promiseResolve, err: null, result: convertResult( result ) } ),
                         (err) => resolve( { state: States.promiseReject, err, result: null } )
                     );
                 }
@@ -223,8 +228,8 @@ class LambdaRunner {
             ...this.context,
 
             fail: ( err ) => resolve( { state: States.contextFail, err } ),
-            succeed: ( result ) => resolve( { state: States.contextSucceed, result } ),
-            done: ( err, result ) => resolve( { state: err ? States.contextFail : States.contextSucceed, err, result } ),
+            succeed: ( result ) => resolve( { state: States.contextSucceed, result: convertResult(result) } ),
+            done: ( err, result ) => resolve( { state: err ? States.contextFail : States.contextSucceed, err, result: convertResult( result ) } ),
             getRemainingTimeInMillis: () => {
 
                     let remaining = this.timeout - (Date.now() - additional.startTime);


### PR DESCRIPTION
The actual parameter used to send input to the lambda and get output from said lambda is simply a string value called the `Payload`.  Therefore, the only way for the AWS SDK to send objects to the lambda and get object from said lambda is through JSON.  However, before this PR, _lambda-tester_ was passing these objects nakedly (since all parties are just JavaScript), which caused subtle deviations of behaviour from actually invoking an AWS lambda.

This PR fixes this by simulating this serialization process in both input and output.  Tests have been modified and added to enforce this behaviour.  The existing code style should be preserved.